### PR TITLE
add timestamp to pointcloud message

### DIFF
--- a/RGLServerPlugin/include/RGLServerPluginInstance.hh
+++ b/RGLServerPlugin/include/RGLServerPluginInstance.hh
@@ -69,7 +69,7 @@ private:
                         bool paused);
     void RayTrace(std::chrono::steady_clock::duration sim_time);
 
-    ignition::msgs::PointCloudPacked CreatePointCloudMsg(std::string frame, int hitpointCount);
+    ignition::msgs::PointCloudPacked CreatePointCloudMsg(std::chrono::steady_clock::duration sim_time, std::string frame, int hitpointCount);
 
     void DestroyLidar();
 

--- a/RGLServerPlugin/src/Lidar.cc
+++ b/RGLServerPlugin/src/Lidar.cc
@@ -162,7 +162,7 @@ void RGLServerPluginInstance::RayTrace(std::chrono::steady_clock::duration simTi
         return;
     }
 
-    auto msg = CreatePointCloudMsg(frameId, hitpointCount);
+    auto msg = CreatePointCloudMsg(simTime, frameId, hitpointCount);
     pointCloudPublisher.Publish(msg);
 
     if (pointCloudWorldPublisher.HasConnections()) {
@@ -172,17 +172,18 @@ void RGLServerPluginInstance::RayTrace(std::chrono::steady_clock::duration simTi
             ignerr << "Failed to get visualization data from RGL lidar.\n";
             return;
         }
-        auto worldMsg = CreatePointCloudMsg(worldFrameId, hitpointCount);
+        auto worldMsg = CreatePointCloudMsg(simTime, worldFrameId, hitpointCount);
         pointCloudWorldPublisher.Publish(worldMsg);
     }
 }
 
-ignition::msgs::PointCloudPacked RGLServerPluginInstance::CreatePointCloudMsg(std::string frame, int hitpointCount)
+ignition::msgs::PointCloudPacked RGLServerPluginInstance::CreatePointCloudMsg(std::chrono::steady_clock::duration simTime, std::string frame, int hitpointCount)
 {
     ignition::msgs::PointCloudPacked outMsg;
     ignition::msgs::InitPointCloudPacked(outMsg, frame, false,
                                          {{"xyz", ignition::msgs::PointCloudPacked::Field::FLOAT32}});
     outMsg.mutable_data()->resize(hitpointCount * outMsg.point_step());
+    *outMsg.mutable_header()->mutable_stamp() = ignition::msgs::Convert(simTime);
     outMsg.set_height(1);
     outMsg.set_width(hitpointCount);
 


### PR DESCRIPTION
PointCloudPacked message did not have a timestamp field, https://github.com/RobotecAI/RGLGazeboPlugin/issues/16. 

This change fixes this and adds the timestamp. 

Resulting message header:
![Screenshot from 2023-05-23 13-25-05](https://github.com/RobotecAI/RGLGazeboPlugin/assets/122796478/a9e3d544-da5c-4e23-8712-22cadfba5676)
