### PR TITLE
Add Laserscan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Inside the link entity in your model, add a custom sensor:
 
 - **pattern_\<type\>** - definition of the lidar firing pattern. Each type has different parameters described below.
 
+- **publish_laserscan** - When using a uniform pattern for a 2D lidar which has vertical samples set to 1, you can choose to publish `LaserScan` messages instead of `PointCloudPacked` messages by setting this parameter to `true`. See example below. 
 ### Pattern types:
 
 - **pattern_uniform**\
@@ -139,6 +140,32 @@ Inside the link entity in your model, add a custom sensor:
       </vertical>
   </pattern_uniform>
   ```
+  **Note:** - Optionally for 2D lidar patterns (vertical samples = 1), you can use the `<publish_laserscan>` param like this
+  ```xml
+  <sensor name="UniformPattern2DLidar" type="custom">
+    <plugin filename="RGLServerPluginInstance" name="rgl::RGLServerPluginInstance">
+      <range>100</range>
+      <update_rate>10</update_rate>
+      <update_on_paused_sim>false</update_on_paused_sim>
+      <topic>rgl_lidar</topic>
+      <frame>RGLLidar</frame>
+      <pattern_uniform>
+        <horizontal>
+            <samples>1800</samples>
+            <min_angle>-3.14159</min_angle>
+            <max_angle>3.14159</max_angle>
+        </horizontal>
+        <vertical>
+            <samples>1</samples>
+            <min_angle>-0.436332</min_angle>
+            <max_angle>0.261799</max_angle>
+        </vertical>
+    </pattern_uniform>
+    <publish_laserscan>true</publish_laserscan>
+    </plugin>
+  </sensor>
+  ```
+
 
 - **pattern_custom**\
   **channels** attribute defines the angular position of lidar channels (angles in radians). Horizontal samples are uniformly distributed.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Inside the link entity in your model, add a custom sensor:
 
 - **pattern_\<type\>** - definition of the lidar firing pattern. Each type has different parameters described below.
 
-- **publish_laserscan** - When using a uniform pattern for a 2D lidar which has vertical samples set to 1, you can choose to publish `LaserScan` messages instead of `PointCloudPacked` messages by setting this parameter to `true`. See example below. 
 ### Pattern types:
 
 - **pattern_uniform**\
@@ -140,32 +139,6 @@ Inside the link entity in your model, add a custom sensor:
       </vertical>
   </pattern_uniform>
   ```
-  **Note:** - Optionally for 2D lidar patterns (vertical samples = 1), you can use the `<publish_laserscan>` param like this
-  ```xml
-  <sensor name="UniformPattern2DLidar" type="custom">
-    <plugin filename="RGLServerPluginInstance" name="rgl::RGLServerPluginInstance">
-      <range>100</range>
-      <update_rate>10</update_rate>
-      <update_on_paused_sim>false</update_on_paused_sim>
-      <topic>rgl_lidar</topic>
-      <frame>RGLLidar</frame>
-      <pattern_uniform>
-        <horizontal>
-            <samples>1800</samples>
-            <min_angle>-3.14159</min_angle>
-            <max_angle>3.14159</max_angle>
-        </horizontal>
-        <vertical>
-            <samples>1</samples>
-            <min_angle>-0.436332</min_angle>
-            <max_angle>0.261799</max_angle>
-        </vertical>
-    </pattern_uniform>
-    <publish_laserscan>true</publish_laserscan>
-    </plugin>
-  </sensor>
-  ```
-
 
 - **pattern_custom**\
   **channels** attribute defines the angular position of lidar channels (angles in radians). Horizontal samples are uniformly distributed.
@@ -210,6 +183,29 @@ Inside the link entity in your model, add a custom sensor:
 
   ```xml
   <pattern_preset_path>/home/some1/your-preset.mat3x4f</pattern_preset_path>
+  ```
+
+- **pattern_lidar2d**\
+  Almost the same as `pattern_uniform` but only has 
+  the `horizontal` element and publishes a 
+  `LaserScan` message instead of a point cloud
+  ```xml
+  <sensor name="Pattern2DLidar" type="custom">
+    <plugin filename="RGLServerPluginInstance" name="rgl::RGLServerPluginInstance">
+      <range>100</range>
+      <update_rate>10</update_rate>
+      <update_on_paused_sim>false</update_on_paused_sim>
+      <topic>rgl_lidar</topic>
+      <frame>RGLLidar</frame>
+      <pattern_lidar2d>
+        <horizontal>
+            <samples>1800</samples>
+            <min_angle>-3.14159</min_angle>
+            <max_angle>3.14159</max_angle>
+        </horizontal>
+    </pattern_lidar2d>
+    </plugin>
+  </sensor>
   ```
 
 ## How to visualize in Gazebo

--- a/RGLServerPlugin/include/LidarPatternLoader.hh
+++ b/RGLServerPlugin/include/LidarPatternLoader.hh
@@ -30,6 +30,7 @@ public:
     using LoadFuncType = std::function<bool(const sdf::ElementConstPtr&, std::vector<rgl_mat3x4f>&)>;
 
     static bool Load(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
+
 private:
     LidarPatternLoader() {};
 

--- a/RGLServerPlugin/include/LidarPatternLoader.hh
+++ b/RGLServerPlugin/include/LidarPatternLoader.hh
@@ -30,8 +30,6 @@ public:
     using LoadFuncType = std::function<bool(const sdf::ElementConstPtr&, std::vector<rgl_mat3x4f>&)>;
 
     static bool Load(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
-    static std::vector<ignition::math::Angle> RglMat3x4fToAngles(const rgl_mat3x4f& rglMatrix);
-
 private:
     LidarPatternLoader() {};
 

--- a/RGLServerPlugin/include/LidarPatternLoader.hh
+++ b/RGLServerPlugin/include/LidarPatternLoader.hh
@@ -30,6 +30,7 @@ public:
     using LoadFuncType = std::function<bool(const sdf::ElementConstPtr&, std::vector<rgl_mat3x4f>&)>;
 
     static bool Load(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
+    static std::vector<ignition::math::Angle> RglMat3x4fToAngles(const rgl_mat3x4f& rglMatrix);
 
 private:
     LidarPatternLoader() {};
@@ -47,7 +48,6 @@ private:
     static rgl_mat3x4f AnglesToRglMat3x4f(const ignition::math::Angle& roll,
                                           const ignition::math::Angle& pitch,
                                           const ignition::math::Angle& yaw);
-    static std::vector<ignition::math::Angle> RglMat3x4fToAngles(const rgl_mat3x4f& rglMatrix);
 
     template<typename T>
     static std::vector<T> LoadVector(const std::filesystem::path& path);

--- a/RGLServerPlugin/include/LidarPatternLoader.hh
+++ b/RGLServerPlugin/include/LidarPatternLoader.hh
@@ -42,11 +42,13 @@ private:
     static bool LoadPatternFromCustom(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
     static bool LoadPatternFromPreset(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
     static bool LoadPatternFromPresetPath(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
+    static bool LoadPatternFromLidar2d(const sdf::ElementConstPtr& sdf, std::vector<rgl_mat3x4f>& outPattern);
 
     static rgl_mat3x4f AnglesToRglMat3x4f(const ignition::math::Angle& roll,
                                           const ignition::math::Angle& pitch,
                                           const ignition::math::Angle& yaw);
-    
+    static std::vector<ignition::math::Angle> RglMat3x4fToAngles(const rgl_mat3x4f& rglMatrix);
+
     template<typename T>
     static std::vector<T> LoadVector(const std::filesystem::path& path);
 

--- a/RGLServerPlugin/include/RGLServerPluginInstance.hh
+++ b/RGLServerPlugin/include/RGLServerPluginInstance.hh
@@ -92,10 +92,6 @@ private:
     ignition::transport::Node::Publisher pointCloudWorldPublisher;
     ignition::transport::Node gazeboNode;
 
-    ignition::math::Angle scanHMin;
-    ignition::math::Angle scanHMax;
-    int scanHSamples;
-
     rgl_node_t rglNodeUseRays = nullptr;
     rgl_node_t rglNodeLidarPose = nullptr;
     rgl_node_t rglNodeRaytrace = nullptr;

--- a/RGLServerPlugin/include/RGLServerPluginInstance.hh
+++ b/RGLServerPlugin/include/RGLServerPluginInstance.hh
@@ -69,8 +69,6 @@ private:
                         bool paused);
     void RayTrace(std::chrono::steady_clock::duration sim_time);
 
-    bool LoadLaserScanParams(const std::shared_ptr<const sdf::Element>& sdf);
-
     ignition::msgs::PointCloudPacked CreatePointCloudMsg(std::chrono::steady_clock::duration sim_time, std::string frame, int hitpointCount);
     ignition::msgs::LaserScan CreateLaserScanMsg(std::chrono::steady_clock::duration sim_time, std::string frame, int hitpointCount);
 
@@ -95,6 +93,7 @@ private:
     rgl_node_t rglNodeUseRays = nullptr;
     rgl_node_t rglNodeLidarPose = nullptr;
     rgl_node_t rglNodeRaytrace = nullptr;
+    rgl_node_t rglNodeCompact = nullptr;
     rgl_node_t rglNodeYield = nullptr;
     rgl_node_t rglNodeToLidarFrame = nullptr;
 

--- a/RGLServerPlugin/include/RGLServerPluginInstance.hh
+++ b/RGLServerPlugin/include/RGLServerPluginInstance.hh
@@ -77,6 +77,9 @@ private:
     std::string topicName;
     std::string frameId;
     float lidarRange;
+    ignition::math::Angle scanHMin;
+    ignition::math::Angle scanHMax;
+    int scanHSamples;
     std::vector<rgl_mat3x4f> lidarPattern;
     std::vector<rgl_vec3f> resultPointCloud;
     std::vector<float> resultDistances;

--- a/RGLServerPlugin/include/RGLServerPluginInstance.hh
+++ b/RGLServerPlugin/include/RGLServerPluginInstance.hh
@@ -69,7 +69,10 @@ private:
                         bool paused);
     void RayTrace(std::chrono::steady_clock::duration sim_time);
 
+    bool LoadLaserScanParams(const std::shared_ptr<const sdf::Element>& sdf);
+
     ignition::msgs::PointCloudPacked CreatePointCloudMsg(std::chrono::steady_clock::duration sim_time, std::string frame, int hitpointCount);
+    ignition::msgs::LaserScan CreateLaserScanMsg(std::chrono::steady_clock::duration sim_time, std::string frame, int hitpointCount);
 
     void DestroyLidar();
 
@@ -78,18 +81,25 @@ private:
     float lidarRange;
     std::vector<rgl_mat3x4f> lidarPattern;
     std::vector<rgl_vec3f> resultPointCloud;
+    std::vector<float> resultDistances;
 
     bool updateOnPausedSim = false;
+    bool publishLaserScan = false;
 
     ignition::gazebo::Entity thisLidarEntity;
     ignition::transport::Node::Publisher pointCloudPublisher;
+    ignition::transport::Node::Publisher laserScanPublisher;
     ignition::transport::Node::Publisher pointCloudWorldPublisher;
     ignition::transport::Node gazeboNode;
+
+    ignition::math::Angle scanHMin;
+    ignition::math::Angle scanHMax;
+    int scanHSamples;
 
     rgl_node_t rglNodeUseRays = nullptr;
     rgl_node_t rglNodeLidarPose = nullptr;
     rgl_node_t rglNodeRaytrace = nullptr;
-    rgl_node_t rglNodeCompact = nullptr;
+    rgl_node_t rglNodeYield = nullptr;
     rgl_node_t rglNodeToLidarFrame = nullptr;
 
     std::chrono::steady_clock::duration raytraceIntervalTime;

--- a/RGLServerPlugin/src/Lidar.cc
+++ b/RGLServerPlugin/src/Lidar.cc
@@ -128,7 +128,7 @@ void RGLServerPluginInstance::CreateLidar(ignition::gazebo::Entity entity,
         if(!CheckRGL(rgl_graph_node_add_child(rglNodeToLidarFrame, rglNodeYield))) {
             ignerr << "Failed to connect RGL nodes when initializing lidar. Disabling plugin.\n";
         }
-        ignmsg << "Topic: " << topicName << " is PointCloudPacked.\n";
+        ignmsg << "Start publishing PointCloudPacked messages on topic '" << topicName << "'\n";
         pointCloudPublisher = gazeboNode.Advertise<ignition::msgs::PointCloudPacked>(topicName);
 
     } else {
@@ -136,7 +136,7 @@ void RGLServerPluginInstance::CreateLidar(ignition::gazebo::Entity entity,
         if(!CheckRGL(rgl_graph_node_add_child(rglNodeRaytrace, rglNodeYield))) {
             ignerr << "Failed to connect RGL nodes when initializing lidar. Disabling plugin.\n";
         }
-        ignmsg << "Topic: " << topicName << " is LaserScan.\n";
+        ignmsg << "Start publishing LaserScan messages on topic '" << topicName << "'\n";
         laserScanPublisher = gazeboNode.Advertise<ignition::msgs::LaserScan>(topicName);
 
     }
@@ -201,7 +201,7 @@ void RGLServerPluginInstance::RayTrace(std::chrono::steady_clock::duration simTi
             }
     } else {
         if (!CheckRGL(rgl_graph_get_result_size(rglNodeRaytrace, RGL_FIELD_DISTANCE_F32, &hitpointCount, nullptr)) ||
-            !CheckRGL(rgl_graph_get_result_data(rglNodeRaytrace, RGL_FIELD_DISTANCE_F32, resultDistances.data()))) {
+            !CheckRGL(rgl_graph_get_result_data(rglNodeYield, RGL_FIELD_DISTANCE_F32, resultDistances.data()))) {
 
         ignerr << "Failed to get result distances from RGL lidar.\n";
         return;

--- a/RGLServerPlugin/src/Lidar.cc
+++ b/RGLServerPlugin/src/Lidar.cc
@@ -193,14 +193,14 @@ void RGLServerPluginInstance::RayTrace(std::chrono::steady_clock::duration simTi
     int32_t hitpointCount = 0;
 
     if (!publishLaserScan) {
-        if (!CheckRGL(rgl_graph_get_result_size(rglNodeToLidarFrame, RGL_FIELD_XYZ_F32, &hitpointCount, nullptr)) ||
+        if (!CheckRGL(rgl_graph_get_result_size(rglNodeYield, RGL_FIELD_XYZ_F32, &hitpointCount, nullptr)) ||
             !CheckRGL(rgl_graph_get_result_data(rglNodeYield, RGL_FIELD_XYZ_F32, resultPointCloud.data()))) {
 
             ignerr << "Failed to get result data from RGL lidar.\n";
             return;
             }
     } else {
-        if (!CheckRGL(rgl_graph_get_result_size(rglNodeRaytrace, RGL_FIELD_DISTANCE_F32, &hitpointCount, nullptr)) ||
+        if (!CheckRGL(rgl_graph_get_result_size(rglNodeYield, RGL_FIELD_DISTANCE_F32, &hitpointCount, nullptr)) ||
             !CheckRGL(rgl_graph_get_result_data(rglNodeYield, RGL_FIELD_DISTANCE_F32, resultDistances.data()))) {
 
         ignerr << "Failed to get result distances from RGL lidar.\n";

--- a/RGLServerPlugin/src/Lidar.cc
+++ b/RGLServerPlugin/src/Lidar.cc
@@ -306,6 +306,8 @@ ignition::msgs::LaserScan RGLServerPluginInstance::CreateLaserScanMsg(std::chron
     if (outMsg.ranges_size() != hitpointCount) {
         for (int i=0; i < hitpointCount; ++i) {
             outMsg.add_ranges(resultDistances[i]);
+            outMsg.add_intensities(100.0);
+
         }
     }
 

--- a/RGLServerPlugin/src/Lidar.cc
+++ b/RGLServerPlugin/src/Lidar.cc
@@ -214,7 +214,7 @@ void RGLServerPluginInstance::RayTrace(std::chrono::steady_clock::duration simTi
 
     if (pointCloudWorldPublisher.HasConnections()) {
         if (!CheckRGL(rgl_graph_get_result_size(rglNodeToLidarFrame, RGL_FIELD_XYZ_F32, &hitpointCount, nullptr)) ||
-            !CheckRGL(rgl_graph_get_result_data(rglNodeYield, RGL_FIELD_XYZ_F32, resultPointCloud.data()))) {
+            !CheckRGL(rgl_graph_get_result_data(rglNodeCompact, RGL_FIELD_XYZ_F32, resultPointCloud.data()))) {
 
             ignerr << "Failed to get visualization data from RGL lidar.\n";
             return;

--- a/RGLServerPlugin/src/LidarPatternLoader.cc
+++ b/RGLServerPlugin/src/LidarPatternLoader.cc
@@ -37,7 +37,7 @@ std::map<std::string, LidarPatternLoader::LoadFuncType> LidarPatternLoader::patt
     {"pattern_uniform", std::bind(&LidarPatternLoader::LoadPatternFromUniform, _1, _2)},
     {"pattern_custom", std::bind(&LidarPatternLoader::LoadPatternFromCustom, _1, _2)},
     {"pattern_preset", std::bind(&LidarPatternLoader::LoadPatternFromPreset, _1, _2)},
-    {"pattern_preset_path", std::bind(&LidarPatternLoader::LoadPatternFromPresetPath, _1, _2)}
+    {"pattern_preset_path", std::bind(&LidarPatternLoader::LoadPatternFromPresetPath, _1, _2)},
     {"pattern_lidar2d", std::bind(&LidarPatternLoader::LoadPatternFromLidar2d, _1, _2)}
 };
 

--- a/RGLServerPlugin/src/LidarPatternLoader.cc
+++ b/RGLServerPlugin/src/LidarPatternLoader.cc
@@ -228,6 +228,7 @@ bool LidarPatternLoader::LoadPatternFromLidar2d(const sdf::ElementConstPtr& sdf,
         return false;
     }
 
+    outPattern.clear();
     outPattern.reserve(hSamples);
 
     ignition::math::Angle hStep((hMax - hMin) / static_cast<double>(hSamples));

--- a/RGLServerPlugin/src/LidarPatternLoader.cc
+++ b/RGLServerPlugin/src/LidarPatternLoader.cc
@@ -289,26 +289,4 @@ rgl_mat3x4f LidarPatternLoader::AnglesToRglMat3x4f(const ignition::math::Angle& 
     return rglMatrix;
 }
 
-std::vector<ignition::math::Angle> LidarPatternLoader::RglMat3x4fToAngles(const rgl_mat3x4f& rglMatrix)
-{
-    ignition::math::Matrix4d matrix4D;
-    ignition::math::Quaterniond quaternion;
-    ignition::math::Vector3d euler;
-    std::vector<ignition::math::Angle> angles;
-
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 4; ++j) {
-            matrix4D(i, j) = rglMatrix.value[i][j];
-        }
-    }
-
-    quaternion = matrix4D.Rotation();
-    euler = quaternion.Euler();
-    for (int i = 0; i < 3; ++i) {
-        angles[i] = ignition::math::Angle(euler[i]);
-    }
-
-    return angles;
-}
-
 }  // namespace rgl


### PR DESCRIPTION
Issue link: https://github.com/RobotecAI/RGLGazeboPlugin/issues/26

**Testing**
---
Tested on Ubuntu 22.04.

- Follow normal build and install instructions
- Modify the `test_world/rgl_playground.sdf`.
- ~~Add `<publish_laserscan>true</publish_laserscan>` in the [plugin element here](https://github.com/RobotecAI/RGLGazeboPlugin/blob/2be4728693e7ccb4e69ef967116af2a4c7ab9c21/test_world/sonoma_with_rgl.sdf#L158)~~
- Replace the [pattern type](https://github.com/RobotecAI/RGLGazeboPlugin/blob/2be4728693e7ccb4e69ef967116af2a4c7ab9c21/test_world/rgl_playground.sdf#L87) of the lidar in `rgl_playground` to the following
 ```
<pattern_lidar2d>
  <horizontal>
      <samples>1800</samples>
      <min_angle>-3.14159</min_angle>
      <max_angle>3.14159</max_angle>
  </horizontal>
</pattern_lidar2d>
```
- Run the demo and try `ign topic -i -t /rgl_lidar` You should see the message is `ignition.msgs.LaserScan` 
- Optionally you can run the `ros2_gz_bridge` to verify in RViz as well.

**Additions**
---
- ~~`LoadLaserScanParams` function  to verify and parse field info for laserscan msg~~
- `LoadPatternFromLidar2d` function for creating a 2D lidar
- `CreateLaserScanMsg` funciton to create the laserscan message
- ~~`<publish_laserscan>`~~ param check logic in `LoadConfiguration` and `publishLaserScan` flag to decide which type of message to advertise and publish
- Documentation in Readme
---
**Modifications**
---
- ~~[MAJOR] Changed API result node from `rglNodeCompact` to `rglNodeYield` to be able to use `rgl_node_points_yield` instead of `rgl_node_points_compact`. This allows to get the range values by adding `RGL_FIELD_DISTANCE_F32` to the result fields  alongside `RGL_FIELD_XYZ_F32` for the pointcloud~~
---
**Notes**
- The `LaserScan` messages need to have an intensity or the `ros2_gz_bridge` will not be happy and seg faults. I have set a static `100.0` value to all the intensity value here but we can easily get that from the API as well with the `rgl_node_points_yield` API call.
However, this relates to https://github.com/RobotecAI/RGLGazeboPlugin/issues/15, So I have excluded adding the `RGL_FILED_INTENSITY_F32` to the `yieldFields` to obtain the intensity value here. (will be happy to come up with a PR for this as well if there is nothing planned for it yet)  
- ~~I have restricted the usage of the `publish_laserscan` param to only unifrom 2D patterns, but can extend to `pattern_custom` if requested (not very familiar with that option)~~