### PR TITLE
Fix RGL_FORCE_DOWNLOAD flag (type specification)

### DIFF
--- a/RGLServerPlugin/CMakeLists.txt
+++ b/RGLServerPlugin/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(ignition-plugin1 REQUIRED)
 include_directories(include)
 
 # Use this variable to make sure the downloaded RGL will be up-to-date
-set(RGL_FORCE_DOWNLOAD OFF BOOL)
+set(RGL_FORCE_DOWNLOAD OFF CACHE BOOL
+    "Removes existing RGL binaries and downloads a new one")
 
 set(RGL_TAG "v0.17.0")
 


### PR DESCRIPTION
The type of the CMake variable was not considered without `CACHE` property. It resulted in the flag being iterated as true every time.