### PR TITLE
Separate RobotecGPULidar project to external directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@
 build
 install
 cmake-build-debug
-RGLServerPlugin/include/rgl
+
+external/*
+!external/CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.21)
 project(RGLGazeboPlugin)
 
-set(CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/install")
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/install")
+endif()
 
 add_subdirectory(external)
 add_subdirectory(RGLServerPlugin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 project(RGLGazeboPlugin)
 
 set(CMAKE_INSTALL_PREFIX "${PROJECT_SOURCE_DIR}/install")
 
+add_subdirectory(external)
 add_subdirectory(RGLServerPlugin)
 add_subdirectory(RGLVisualize)

--- a/README.md
+++ b/README.md
@@ -53,13 +53,28 @@ Key features:
 ```shell
 mkdir build
 cd build
-cmake .. # Add `-DRGL_FORCE_DOWNLOAD=ON` to make sure the downloaded RGL will be up-to-date
+cmake ..
 make -j
 make install
 cd ..
 export GZ_SIM_SYSTEM_PLUGIN_PATH=`pwd`/install/RGLServerPlugin:$GZ_SIM_SYSTEM_PLUGIN_PATH
 export GZ_GUI_PLUGIN_PATH=`pwd`/install/RGLVisualize:$GZ_GUI_PLUGIN_PATH
 ```
+
+#### Using custom build of RobotecGPULidar
+
+By default, the `RGLGazebPlugin` downloads `RobotecGPULidar` binaries from [the official release](https://github.com/RobotecAI/RobotecGPULidar/releases). To use your own build of `RobotecGPULidar`, set the following CMake variables when configuring the project:
+```shell
+# RGL_CUSTOM_LIBRARY_PATH - Path to the custom RobotecGPULidar library build
+# RGL_CUSTOM_API_HEADER_PATH - Path to the include directory with API headers compatible with the custom library build
+#                              (`include` directory of `RobotecGPULidar` project)
+# Example:
+cmake \
+  -DRGL_CUSTOM_LIBRARY_PATH="$HOME/RobotecGPULidar/build/lib/libRobotecGPULidar.so" \
+  -DRGL_CUSTOM_API_HEADER_PATH="$HOME/RobotecGPULidar/include" \
+  ..
+```
+
 ## Demo:
 
 ![](docs/videos/prius.gif)

--- a/RGLServerPlugin/CMakeLists.txt
+++ b/RGLServerPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 project(RGLServerPlugin)
 set(CMAKE_CXX_STANDARD 20)
 
@@ -9,59 +9,23 @@ set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 gz_find_package(gz-sim8 REQUIRED)
 set(GZ_SIM_VER ${gz-sim8_VERSION_MAJOR})
 
-
 include_directories(include)
 
-# Use this variable to make sure the downloaded RGL will be up-to-date
-set(RGL_FORCE_DOWNLOAD OFF CACHE BOOL
-    "Removes existing RGL binaries and downloads a new one")
-
-set(RGL_TAG "v0.17.0")
-
-set(RGL_PATH "${CMAKE_CURRENT_SOURCE_DIR}/include/rgl")
-set(RGL_SO_FILENAME "libRobotecGPULidar.so")
-set(RGL_SO_PATH "${RGL_PATH}/${RGL_SO_FILENAME}")
-set(RGL_API_HEADER_PATH "${RGL_PATH}/api/core.h")
-
-set(RGL_SO_ZIP_FILENAME "RGL-core-linux-x64.zip")
-set(RGL_SO_ZIP_URL "https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_SO_ZIP_FILENAME}")
-set(RGL_API_HEADER_URL "https://raw.githubusercontent.com/RobotecAI/RobotecGPULidar/${RGL_TAG}/include/rgl/api/core.h")
-
-if (RGL_FORCE_DOWNLOAD)
-    file(REMOVE_RECURSE ${RGL_PATH})
-endif()
-
-# Download RGL library
-if(NOT EXISTS ${RGL_SO_PATH})
-    file(DOWNLOAD ${RGL_SO_ZIP_URL} ${RGL_PATH}/${RGL_SO_ZIP_FILENAME})
-    file(ARCHIVE_EXTRACT INPUT ${RGL_PATH}/${RGL_SO_ZIP_FILENAME}
-        DESTINATION ${RGL_PATH}
-        PATTERNS ${RGL_SO_FILENAME}
-        VERBOSE
-    )
-    file(REMOVE ${RGL_PATH}/${RGL_SO_ZIP_FILENAME})
-endif()
-
-# Download RGL API header
-if(NOT EXISTS ${RGL_API_PATH})
-    file(DOWNLOAD ${RGL_API_HEADER_URL} ${RGL_API_HEADER_PATH})
-endif()
-
-set(RobotecGPULidar ${RGL_SO_PATH})
-
 add_library(RGLServerPluginManager SHARED src/RGLServerPluginManager.cc src/Mesh.cc src/Utils.cc src/Scene.cc)
+target_include_directories(RGLServerPluginManager PRIVATE RobotecGPULidar)
 target_link_libraries(RGLServerPluginManager
     PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
     PRIVATE gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
-    ${RobotecGPULidar}
+    PRIVATE RobotecGPULidar
 )
 set_target_properties(RGLServerPluginManager PROPERTIES INSTALL_RPATH "$ORIGIN")
 
 add_library(RGLServerPluginInstance SHARED src/RGLServerPluginInstance.cc src/Lidar.cc src/Utils.cc src/LidarPatternLoader.cc)
+target_include_directories(RGLServerPluginInstance PRIVATE RobotecGPULidar)
 target_link_libraries(RGLServerPluginInstance
     PRIVATE gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
     PRIVATE gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
-    ${RobotecGPULidar}
+    PRIVATE RobotecGPULidar
 )
 set_target_properties(RGLServerPluginInstance PROPERTIES INSTALL_RPATH "$ORIGIN")
 
@@ -70,6 +34,7 @@ set_target_properties(RGLServerPluginInstance PROPERTIES INSTALL_RPATH "$ORIGIN"
 install(TARGETS RGLServerPluginInstance RGLServerPluginManager
     DESTINATION RGLServerPlugin
 )
-install(FILES ${RobotecGPULidar}
+# RobotecGPULidar needs to be installed manually as it is a dependent shared library
+install(IMPORTED_RUNTIME_ARTIFACTS RobotecGPULidar
     DESTINATION RGLServerPlugin
 )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,51 +3,53 @@
 # RobotecGPULidar
 ########################################################################
 
-# Expected project tree:
-# RobotecGPULidar
-# ├── include
-# │   └── rgl
-# │       └── api
-# │           └── core.h
-# └── lib
-#     └── libRobotecGPULidar.so
-
-# Use this variable to make sure the downloaded RGL will be up-to-date
-set(RGL_FORCE_DOWNLOAD OFF CACHE BOOL
-    "Removes existing RGL binaries and downloads a new one")
-
-set(RGL_TAG "v0.17.0")
-
-set(RGL_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/RobotecGPULidar")
+set(RGL_PROJECT_DIR "${CMAKE_CURRENT_BINARY_DIR}/RobotecGPULidar")
 set(RGL_LIBRARY_DIR "${RGL_PROJECT_DIR}/lib")
 set(RGL_SO_FILENAME "libRobotecGPULidar.so")
 set(RGL_SO_PATH "${RGL_LIBRARY_DIR}/${RGL_SO_FILENAME}")
 set(RGL_INCLUDE_DIR "${RGL_PROJECT_DIR}/include")
-set(RGL_API_HEADER_PATH "${RGL_INCLUDE_DIR}/rgl/api/core.h")
+set(RGL_API_HEADERS_DIR "${RGL_INCLUDE_DIR}/rgl/api")
 
-set(RGL_SO_ZIP_FILENAME "RGL-core-linux-x64.zip")
-set(RGL_SO_ZIP_URL "https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_SO_ZIP_FILENAME}")
-set(RGL_API_HEADER_URL "https://raw.githubusercontent.com/RobotecAI/RobotecGPULidar/${RGL_TAG}/include/rgl/api/core.h")
+set(RGL_CUSTOM_LIBRARY_PATH "" CACHE FILEPATH
+    "Path to the custom RobotecGPULidar library build. An alternative to release downloading.")
+set(RGL_CUSTOM_API_HEADER_PATH "" CACHE PATH
+    "Path to the include directory with API headers compatible with the custom library build
+     provided with `RGL_CUSTOM_LIBRARY_FILEPATH`.
+     In most cases it will be path to `include` directory of RobotecGPULidar project")
 
-if (RGL_FORCE_DOWNLOAD)
-    file(REMOVE_RECURSE ${RGL_PROJECT_DIR})
+if((RGL_CUSTOM_LIBRARY_PATH AND NOT RGL_CUSTOM_API_HEADER_PATH) OR
+    NOT RGL_CUSTOM_LIBRARY_PATH AND RGL_CUSTOM_API_HEADER_PATH)
+    message(FATAL_ERROR "It is required to set both `RGL_CUSTOM_LIBRARY_PATH` and `RGL_CUSTOM_API_HEADER_PATH`\
+                         to finish custom RobotecGPULidar configuration")
 endif()
 
-# Download RGL library if not present
-if(NOT EXISTS ${RGL_SO_PATH})
-    set(RGL_SO_ZIP_PATH "${RGL_LIBRARY_DIR}/${RGL_SO_ZIP_FILENAME}")
-    file(DOWNLOAD ${RGL_SO_ZIP_URL} ${RGL_SO_ZIP_PATH})
-    file(ARCHIVE_EXTRACT INPUT ${RGL_SO_ZIP_PATH}
-        DESTINATION ${RGL_LIBRARY_DIR}
-        PATTERNS ${RGL_SO_FILENAME}
-        VERBOSE
-    )
-    file(REMOVE ${RGL_SO_ZIP_PATH})
-endif()
+if(RGL_CUSTOM_LIBRARY_PATH AND RGL_CUSTOM_API_HEADER_PATH) # Copy custom RobotecGPULidar from the provided location
+    file(MAKE_DIRECTORY ${RGL_LIBRARY_DIR})
+    file(COPY ${RGL_CUSTOM_LIBRARY_PATH} DESTINATION ${RGL_LIBRARY_DIR})
+    file(COPY ${RGL_CUSTOM_API_HEADER_PATH} DESTINATION ${RGL_PROJECT_DIR})
+else() # Download RobotecGPULidar from the release
+    set(RGL_TAG "v0.17.0")
+    set(RGL_API_CORE_HEADER_PATH "${RGL_API_HEADERS_DIR}/core.h")
+    set(RGL_SO_ZIP_FILENAME "RGL-core-linux-x64.zip")
+    set(RGL_SO_ZIP_URL "https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_SO_ZIP_FILENAME}")
+    set(RGL_API_CORE_HEADER_URL "https://raw.githubusercontent.com/RobotecAI/RobotecGPULidar/${RGL_TAG}/include/rgl/api/core.h")
 
-# Download RGL API header if not present
-if(NOT EXISTS ${RGL_API_HEADER_PATH})
-    file(DOWNLOAD ${RGL_API_HEADER_URL} ${RGL_API_HEADER_PATH})
+    # Download RGL library if not present
+    if(NOT EXISTS ${RGL_SO_PATH})
+        set(RGL_SO_ZIP_PATH "${RGL_LIBRARY_DIR}/${RGL_SO_ZIP_FILENAME}")
+        file(DOWNLOAD ${RGL_SO_ZIP_URL} ${RGL_SO_ZIP_PATH})
+        file(ARCHIVE_EXTRACT INPUT ${RGL_SO_ZIP_PATH}
+                DESTINATION ${RGL_LIBRARY_DIR}
+                PATTERNS ${RGL_SO_FILENAME}
+                VERBOSE
+        )
+        file(REMOVE ${RGL_SO_ZIP_PATH})
+    endif()
+
+    # Download RGL API header if not present
+    if(NOT EXISTS ${RGL_API_CORE_HEADER_PATH})
+        file(DOWNLOAD ${RGL_API_CORE_HEADER_URL} ${RGL_API_CORE_HEADER_PATH})
+    endif()
 endif()
 
 add_library(RobotecGPULidar SHARED IMPORTED GLOBAL)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,7 +18,7 @@ set(RGL_CUSTOM_API_HEADER_PATH "" CACHE PATH
      In most cases it will be path to `include` directory of RobotecGPULidar project")
 
 if((RGL_CUSTOM_LIBRARY_PATH AND NOT RGL_CUSTOM_API_HEADER_PATH) OR
-    NOT RGL_CUSTOM_LIBRARY_PATH AND RGL_CUSTOM_API_HEADER_PATH)
+   (NOT RGL_CUSTOM_LIBRARY_PATH AND RGL_CUSTOM_API_HEADER_PATH))
     message(FATAL_ERROR "It is required to set both `RGL_CUSTOM_LIBRARY_PATH` and `RGL_CUSTOM_API_HEADER_PATH`\
                          to finish custom RobotecGPULidar configuration")
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,48 @@
+
+########################################################################
+# RobotecGPULidar
+########################################################################
+
+# Use this variable to make sure the downloaded RGL will be up-to-date
+set(RGL_FORCE_DOWNLOAD OFF CACHE BOOL
+    "Removes existing RGL binaries and downloads a new one")
+
+set(RGL_TAG "v0.17.0")
+
+set(RGL_PROJECT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/RobotecGPULidar")
+set(RGL_LIBRARY_DIR "${RGL_PROJECT_DIR}/lib")
+set(RGL_SO_FILENAME "libRobotecGPULidar.so")
+set(RGL_SO_PATH "${RGL_LIBRARY_DIR}/${RGL_SO_FILENAME}")
+set(RGL_INCLUDE_DIR "${RGL_PROJECT_DIR}/include")
+set(RGL_API_HEADER_PATH "${RGL_INCLUDE_DIR}/rgl/api/core.h")
+
+set(RGL_SO_ZIP_FILENAME "RGL-core-linux-x64.zip")
+set(RGL_SO_ZIP_URL "https://github.com/RobotecAI/RobotecGPULidar/releases/download/${RGL_TAG}/${RGL_SO_ZIP_FILENAME}")
+set(RGL_API_HEADER_URL "https://raw.githubusercontent.com/RobotecAI/RobotecGPULidar/${RGL_TAG}/include/rgl/api/core.h")
+
+if (RGL_FORCE_DOWNLOAD)
+    file(REMOVE_RECURSE ${RGL_PROJECT_DIR})
+endif()
+
+# Download RGL library if not present
+if(NOT EXISTS ${RGL_SO_PATH})
+    set(RGL_SO_ZIP_PATH "${RGL_LIBRARY_DIR}/${RGL_SO_ZIP_FILENAME}")
+    file(DOWNLOAD ${RGL_SO_ZIP_URL} ${RGL_SO_ZIP_PATH})
+    file(ARCHIVE_EXTRACT INPUT ${RGL_SO_ZIP_PATH}
+        DESTINATION ${RGL_LIBRARY_DIR}
+        PATTERNS ${RGL_SO_FILENAME}
+        VERBOSE
+    )
+    file(REMOVE ${RGL_SO_ZIP_PATH})
+endif()
+
+# Download RGL API header if not present
+if(NOT EXISTS ${RGL_API_HEADER_PATH})
+    file(DOWNLOAD ${RGL_API_HEADER_URL} ${RGL_API_HEADER_PATH})
+endif()
+
+add_library(RobotecGPULidar SHARED IMPORTED GLOBAL)
+set_target_properties(RobotecGPULidar PROPERTIES
+    IMPORTED_LOCATION ${RGL_SO_PATH}
+    INTERFACE_INCLUDE_DIRECTORIES ${RGL_INCLUDE_DIR}
+)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,6 +3,15 @@
 # RobotecGPULidar
 ########################################################################
 
+# Expected project tree:
+# RobotecGPULidar
+# ├── include
+# │   └── rgl
+# │       └── api
+# │           └── core.h
+# └── lib
+#     └── libRobotecGPULidar.so
+
 # Use this variable to make sure the downloaded RGL will be up-to-date
 set(RGL_FORCE_DOWNLOAD OFF CACHE BOOL
     "Removes existing RGL binaries and downloads a new one")


### PR DESCRIPTION
This PR separates `RobotecGPULidar` project to `external` directory. It makes the Plugin sources read-only.