### PR TITLE
Check entity is not ignored before trying to add laser retro

### DIFF
--- a/RGLServerPlugin/src/Scene.cc
+++ b/RGLServerPlugin/src/Scene.cc
@@ -140,6 +140,15 @@ bool RGLServerPluginManager::SetLaserRetroCb(
         const gz::sim::Entity& entity,
         const gz::sim::components::LaserRetro* laser_retro)
 {
+    if (entitiesToIgnore.contains(entity)) {
+        return true;
+    }
+
+    if (!entitiesInRgl.contains(entity)) {
+        gzerr << "Trying to set Laser Retro for entity (" << entity << ") not loaded to RGL!\n";
+        return true;
+    }
+
     if (!CheckRGL(rgl_entity_set_laser_retro(entitiesInRgl.at(entity).first, laser_retro->Data()))) {
         gzerr << "Failed to set Laser Retro for entity (" << entity << ").\n";
     }


### PR DESCRIPTION
I found an issue when we have a `<laser_retro>` tag in one of the links that are ignored by RGL. The plugin would just crash with `std::out_of_range` since the entity is not in `entitiesInRgl`. The plugin should tolerate this laser retro value even if it's for an ignored entity.

To allow this case we just return in case the entity is ignored, also I added a more informative error message for the case we reach this point and the entity is not loaded yet.