### PR TITLE
Fortress backport - Check entity is not ignored before trying to add laser retro

### DIFF
--- a/RGLServerPlugin/src/Scene.cc
+++ b/RGLServerPlugin/src/Scene.cc
@@ -140,6 +140,15 @@ bool RGLServerPluginManager::SetLaserRetroCb(
         const ignition::gazebo::Entity& entity,
         const ignition::gazebo::components::LaserRetro* laser_retro)
 {
+    if (entitiesToIgnore.contains(entity)) {
+        return true;
+    }
+
+    if (!entitiesInRgl.contains(entity)) {
+        gzerr << "Trying to set Laser Retro for entity (" << entity << ") not loaded to RGL!\n";
+        return true;
+    }
+
     if (!CheckRGL(rgl_entity_set_laser_retro(entitiesInRgl.at(entity).first, laser_retro->Data()))) {
         ignerr << "Failed to set Laser Retro for entity (" << entity << ").\n";
     }


### PR DESCRIPTION
See #44 